### PR TITLE
fix: support namespaced packages

### DIFF
--- a/src/utils/packageDependency.ts
+++ b/src/utils/packageDependency.ts
@@ -69,8 +69,11 @@ export function getDependencyFromYarn(entry: any): PackageDependency | null {
 }
 
 export function getPKGVersion(yarnEntryName: string) {
-    const [entryName] = yarnEntryName.split("@");
-    const pkgPath = path.join(NODE_MODULES_PATH, entryName, "package.json");
+    const atIndex = yarnEntryName.lastIndexOf("@");
+    if (atIndex > 0) {
+        yarnEntryName = yarnEntryName.substring(0, atIndex);
+    }
+    const pkgPath = path.join(NODE_MODULES_PATH, yarnEntryName, "package.json");
     const pkg = require(pkgPath);
 
     return pkg.version;

--- a/tests/utils/packageDependency.test.ts
+++ b/tests/utils/packageDependency.test.ts
@@ -8,6 +8,11 @@ test("utils - getPKGVersion", () => {
     expect(v).toBe("22.4.3");
 });
 
+test("utils - getPKGVersion for namespaced package", () => {
+    const v = getPKGVersion("@sindresorhus/is");
+    expect(v).toBe("0.7.0");
+});
+
 test("utils - getDependencyFromYarn", () => {
     const dep = getDependencyFromYarn("fs-extra");
     expect(Object.keys(dep).length).toBeGreaterThan(0);


### PR DESCRIPTION
This PR allows namespaced packages (e.g. "@material-ui/core") to be used.