### PR TITLE
add prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "author": "clinyong <clinyong@gmail.com>",
     "license": "MIT",
     "scripts": {
+        "prepare": "tsc",
         "test": "jest"
     },
     "keywords": [


### PR DESCRIPTION
This commit adds a prepare script which is run before the package is packed and published or when the package is installed from a github url.